### PR TITLE
Improve port sanitization for Render deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,9 @@ ENV PYTHONUNBUFFERED=1
 # Expose port (Render will set PORT environment variable)
 EXPOSE 8000
 
-# Health check respects PORT if provided (sanitize to integer)
+# Health check uses PORT if valid, defaults to 8000 otherwise
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD sh -c 'PORT_CLEAN=${PORT%%.*}; if [ -z "$PORT_CLEAN" ]; then PORT_CLEAN=8000; fi; curl -f http://localhost:${PORT_CLEAN}/healthz || exit 1'
+    CMD sh -c 'PORT_CLEAN=$(echo "${PORT:-8000}" | grep -Eo "^[0-9]+$"); if [ -z "$PORT_CLEAN" ]; then PORT_CLEAN=8000; fi; curl -f http://localhost:${PORT_CLEAN}/healthz || exit 1'
 
 # Start command via entrypoint script that sanitizes PORT
 CMD ["/app/scripts/start.sh"]

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,14 +1,12 @@
 #!/usr/bin/env sh
 set -eu
 
-# Sanitize PORT to ensure it's an integer (trim trailing decimals)
-PORT_CLEAN=${PORT%%.*}
-if [ -z "${PORT_CLEAN}" ]; then
-  PORT_CLEAN=8000
-fi
+# Sanitize PORT to ensure it is a valid integer
+PORT_CLEAN="$(echo "${PORT:-8000}" | grep -Eo '^[0-9]+$')"
+[ -z "$PORT_CLEAN" ] && PORT_CLEAN=8000
 
-export PORT="${PORT_CLEAN}"
-echo "[start] Using PORT=${PORT}" >&2
+export PORT="$PORT_CLEAN"
+echo "[start] Using PORT=$PORT" >&2
 
-exec uvicorn api.app:app --host 0.0.0.0 --port "${PORT}"
+exec uvicorn api.app:app --host 0.0.0.0 --port "$PORT"
 


### PR DESCRIPTION
## Summary
- Sanitize PORT environment variable via `start.sh`
- Validate PORT in Docker health check before hitting endpoint

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbcbf1d63083269bdfaefa413faec6