### PR TITLE
docs: use start script for Render

### DIFF
--- a/RENDER_DEPLOYMENT.md
+++ b/RENDER_DEPLOYMENT.md
@@ -8,7 +8,8 @@ When creating a new web service on Render, use these settings:
 
 - **Docker Build Context Directory**: `.` (root of repository)
 - **Dockerfile Path**: `./Dockerfile`
-- **Docker Command**: `uvicorn api.app:app --host 0.0.0.0 --port $PORT`
+- **Docker Command**: `/app/scripts/start.sh`
+  *Note*: `start.sh` sanitizes Render's auto-generated `PORT` value before starting the server.
 - **Pre-Deploy Command**: `bash scripts/render_deploy.sh`
 - **Auto-Deploy**: `On Commit`
 - **Build Filters**: Include these paths:


### PR DESCRIPTION
## Summary
- use `/app/scripts/start.sh` in Render Docker command
- note that `start.sh` sanitizes Render's auto-generated PORT value

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bbf3f8f78883268db9e0694ad59508