### PR TITLE
Ensure start script handles invalid PORT gracefully

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Sanitize PORT to ensure it is a valid integer
-PORT_CLEAN="$(echo "${PORT:-8000}" | grep -Eo '^[0-9]+$')"
+PORT_CLEAN="$(printf '%s' "${PORT:-8000}" | grep -Eo '^[0-9]+$' || true)"
 [ -z "$PORT_CLEAN" ] && PORT_CLEAN=8000
 
 export PORT="$PORT_CLEAN"


### PR DESCRIPTION
## Summary
- prevent start script from exiting when PORT contains non-numeric data by ignoring grep failures
- retain default fallback to port 8000 when no valid number is provided

## Testing
- `sh -n scripts/start.sh`
- `pytest` *(no tests ran)*
- `shellcheck scripts/start.sh` *(missing: failed to install due to repository errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf3ecfe6c832688376b0437462cae